### PR TITLE
Fix update nui bank balance after withdraw/deposit through the bank.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -63,7 +63,10 @@ RegisterNUICallback('CloseNUI', function()
 end)
 
 RegisterNUICallback('Transact', function(data)
-    TriggerServerEvent('rpx-banking:Server:Transact', data.type, data.amount)
+    local trans, after = lib.callback.await('rpx-banking:transact', false, data)
+    if trans then
+        SendNUIMessage({action = "OPEN_BANK", balance = after})
+    end
 end)
 
 AddStateBagChangeHandler("bank", nil, function(bagName, key, value) 

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,27 +2,28 @@ RPX = exports['rpx-core']:GetObject()
 
 --@NetEvent: rpx-banking:Server:Transact
 --@description: This event is called by a client when a player is trying to transact money.
-RegisterNetEvent("rpx-banking:Server:Transact", function(type, amount)
-    local src = source
+lib.callback.register('rpx-banking:transact', function(src, data)
+    local type, amount = data.type, data.amount
     local player = RPX.GetPlayer(src)
+    if not player then return false end
+
     amount = tonumber(amount)
     if amount <= 0 then
         lib.notify(src, {title = "Invalid amount.", type = "error"})
-        return
+        return false
     end
-    if type == 1 then
-        if player.money.bank >= amount then
-            player.RemoveMoney('bank', amount)
-            player.AddMoney('cash', amount)
-        else
-            lib.notify(src, {title = "Insufficient funds.", type = "error"})
-        end
-    elseif type == 2 then
-        if player.money.cash >= amount then
-            player.RemoveMoney('cash', amount)
-            player.AddMoney('bank', amount)
-        else
-            lib.notify(src, {title = "Insufficient funds.", type = "error"})
-        end
+    if type == 1 and player.money.bank >= amount then
+        local after = player.money.bank - amount
+        player.RemoveMoney('bank', amount)
+        player.AddMoney('cash', amount)
+        return true, after
+    elseif type == 2 and player.money.cash >= amount then
+        local after = player.money.bank + amount
+        player.RemoveMoney('cash', amount)
+        player.AddMoney('bank', amount)
+        return true, after
+    else
+        lib.notify(src, {title = "Insufficient funds.", type = "error"})
+        return false
     end
 end)


### PR DESCRIPTION
Updated to lib.callback systems, so everytime returns true, will also updates the nui balance inside the bank. (instead of update bank balance when the nui is closed).